### PR TITLE
Update Guides.md

### DIFF
--- a/docs/Guides.md
+++ b/docs/Guides.md
@@ -339,8 +339,7 @@ public class AppsFlyerObject : MonoBehaviour, IStoreListener, IAppsFlyerValidate
     public PurchaseProcessingResult ProcessPurchase(PurchaseEventArgs args)
     {
         string prodID = args.purchasedProduct.definition.id;
-        string price = args.purchasedProduct.metadata.localizedPriceString;
-        string regPrice = Regex.Replace(price, "[^0-9 /.]", "");
+        string price = args.purchasedProduct.metadata.localizedPrice.ToString();
         string currency = args.purchasedProduct.metadata.isoCurrencyCode;
 
         string receipt = args.purchasedProduct.receipt;
@@ -356,7 +355,7 @@ public class AppsFlyerObject : MonoBehaviour, IStoreListener, IAppsFlyerValidate
                 AppsFlyeriOS.setUseReceiptValidationSandbox(true);
             }
 
-            AppsFlyeriOS.validateAndSendInAppPurchase(prodID, regPrice, currency, transactionID, null, this);
+            AppsFlyeriOS.validateAndSendInAppPurchase(prodID, price, currency, transactionID, null, this);
 #endif
         }
 


### PR DESCRIPTION
You should use Unity's localizedPrice instead of the regular expression listed in the docs, because Euro prices come back with commas not periods. So you end up submitting 1099 instead of 10.99. The localizedPrice field of Unity's metadata is a decimal.