### PR TITLE
Fix the return value of openURL

### DIFF
--- a/Assets/AppsFlyer/Plugins/iOS/AppsFlyer+AppController.m
+++ b/Assets/AppsFlyer/Plugins/iOS/AppsFlyer+AppController.m
@@ -124,7 +124,7 @@ BOOL __swizzled_openURL(id self, SEL _cmd, UIApplication* application, NSURL* ur
     if(__original_openUrl_Imp){
         return ((BOOL(*)(id, SEL, UIApplication*, NSURL*, NSDictionary*))__original_openUrl_Imp)(self, _cmd, application, url, options);
     }
-    return YES;
+    return NO;
 }
 
 

--- a/Assets/AppsFlyer/Plugins/iOS/AppsFlyerAppController.mm
+++ b/Assets/AppsFlyer/Plugins/iOS/AppsFlyerAppController.mm
@@ -71,7 +71,7 @@
 -(BOOL) application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary *)options {
     NSLog(@"got openUrl: %@",url);
     [[AppsFlyerLib shared] handleOpenUrl:url options:options];
-    return YES;
+    return NO;
 }
 
 - (void)onOpenURL:(NSNotification*)notification {


### PR DESCRIPTION
The return value of [application:openURL:options:](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application?language=objc) specifies whether the URL was opened successfully or not. The system tries to open the URL sequentially with all the available delegates until it finds one that can open the URL. After that, there's no need to call the remaining ones.

Unconditionally returning `YES` means your delegate can handle ALL the requests and nobody else needs to know about them. Depending on the call order, this leads to issues like https://github.com/AppsFlyerSDK/appsflyer-unity-plugin/issues/47.

[The swizzled version](https://github.com/AppsFlyerSDK/appsflyer-unity-plugin/blob/6e72bee5328c609582d2eafe2b69c599489c140a/Assets/AppsFlyer/Plugins/iOS/AppsFlyer+AppController.m#L121) calls `handleOpenUrl` first and then the original method is always executed, which at least gives a chance to the other handlers.

The ideal solution would be changing `handleOpenUrl` to return a meaningful boolean so we know whether the given URL was aimed at AppsFlyer or not, and then we could act accordingly. It was suggested more than a year ago in https://github.com/AppsFlyerSDK/AppsFlyerFramework/issues/85.