### PR TITLE
Remove an unused variable

### DIFF
--- a/Assets/AppsFlyer/AppsFlyerEventArgs.cs
+++ b/Assets/AppsFlyer/AppsFlyerEventArgs.cs
@@ -140,7 +140,6 @@ namespace AppsFlyerSDK
 
                 string status = "";
                 string error = "";
-                Dictionary<string, object> deepLink;
                 
                 if (dictionary.ContainsKey("status") && dictionary["status"] != null)
                 {


### PR DESCRIPTION
In our project we tell the compiler to error out when it finds unused variables. In this case it triggered this error:
```
AppsFlyerEventArgs.cs(143,44): error CS0168: The variable 'deepLink' is declared but never used
```
I checked the code and it looks like a leftover, so I think it should be safe to remove it.