### PR TITLE
Get rid of instance null checks

### DIFF
--- a/Assets/AppsFlyer/AppsFlyerAndroid.cs
+++ b/Assets/AppsFlyer/AppsFlyerAndroid.cs
@@ -20,7 +20,7 @@ namespace AppsFlyerSDK
         /// </summary>
         /// <param name="devkey"> AppsFlyer's Dev-Key, which is accessible from your AppsFlyer account under 'App Settings' in the dashboard.</param>
         /// <param name="gameObject">The current game object. This is used to get the conversion data callbacks. Pass null if you do not need the callbacks.</param>
-        public void initSDK(string devkey, MonoBehaviour gameObject)
+        public void initSDK(string devKey, string appID, MonoBehaviour gameObject)
         {
 #if !UNITY_EDITOR
              appsFlyerAndroid.CallStatic("initSDK", devkey, gameObject ? gameObject.name : null);

--- a/Assets/AppsFlyer/AppsFlyerDummy.cs
+++ b/Assets/AppsFlyer/AppsFlyerDummy.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AppsFlyerSDK
+{
+    public class AppsFlyerDummy : IAppsFlyerNativeBridge
+    {
+        public bool isInit { get; set; }
+        public void initSDK(string devKey, string appID, MonoBehaviour gameObject)
+        {
+            // ...
+        }
+
+        public void startSDK(bool onRequestResponse, string CallBackObjectName)
+        {
+            // ...
+        }
+
+        public void sendEvent(string eventName, Dictionary<string, string> eventValues, bool onInAppResponse, string CallBackObjectName)
+        {
+            // ...
+        }
+
+        public void stopSDK(bool isSDKStopped)
+        {
+            // ...
+        }
+
+        public bool isSDKStopped()
+        {
+            // ...
+            return true;
+        }
+
+        public string getSdkVersion()
+        {
+            // ...
+            return "";
+        }
+
+        public void setCustomerUserId(string id)
+        {
+            // ...
+        }
+
+        public void setAppInviteOneLinkID(string oneLinkId)
+        {
+            // ...
+        }
+
+        public void setAdditionalData(Dictionary<string, string> customData)
+        {
+            // ...
+        }
+
+        public void setResolveDeepLinkURLs(params string[] urls)
+        {
+            // ...
+        }
+
+        public void setOneLinkCustomDomain(params string[] domains)
+        {
+            // ...
+        }
+
+        public void setCurrencyCode(string currencyCode)
+        {
+            // ...
+        }
+
+        public void recordLocation(double latitude, double longitude)
+        {
+            // ...
+        }
+
+        public void anonymizeUser(bool shouldAnonymizeUser)
+        {
+            // ...
+        }
+
+        public string getAppsFlyerId()
+        {
+            // ...
+            return "";
+        }
+
+        public void setMinTimeBetweenSessions(int seconds)
+        {
+            // ...
+        }
+
+        public void setHost(string hostPrefixName, string hostName)
+        {
+            // ...
+        }
+
+        public void setPhoneNumber(string phoneNumber)
+        {
+            // ...
+        }
+
+        public void setSharingFilterForAllPartners()
+        {
+            // ...
+        }
+
+        public void setSharingFilter(params string[] partners)
+        {
+            // ...
+        }
+
+        public void getConversionData(string objectName)
+        {
+            // ...
+        }
+
+        public void attributeAndOpenStore(string appID, string campaign, Dictionary<string, string> userParams, MonoBehaviour gameObject)
+        {
+            // ...
+        }
+
+        public void recordCrossPromoteImpression(string appID, string campaign, Dictionary<string, string> parameters)
+        {
+            // ...
+        }
+
+        public void generateUserInviteLink(Dictionary<string, string> parameters, MonoBehaviour gameObject)
+        {
+            // ...
+        }
+
+        public void addPushNotificationDeepLinkPath(params string[] paths)
+        {
+            // ...
+        }
+
+        public void setUserEmails(EmailCryptType cryptType, params string[] userEmails)
+        {
+            // ...
+        }
+
+        public void subscribeForDeepLink(string objectName)
+        {
+            // ...
+        }
+
+        public void setIsDebug(bool shouldEnable)
+        {
+            // ...
+        }
+
+        public void setPartnerData(string partnerId, Dictionary<string, string> partnerInfo)
+        {
+            // ...
+        }
+    }
+}

--- a/Assets/AppsFlyer/AppsFlyerDummy.cs.meta
+++ b/Assets/AppsFlyer/AppsFlyerDummy.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b76e45feae894dd08c967987ac2cfc3c
+timeCreated: 1666174872

--- a/Assets/AppsFlyer/AppsFlyeriOS.cs
+++ b/Assets/AppsFlyer/AppsFlyeriOS.cs
@@ -17,7 +17,7 @@ namespace AppsFlyerSDK
 
         public AppsFlyeriOS() { }
 
-        public AppsFlyeriOS(string devKey, string appID, MonoBehaviour gameObject)
+        public void initSDK(string devKey, string appID, MonoBehaviour gameObject)
         {
             setAppsFlyerDevKey(devKey);
             setAppleAppID(appID);

--- a/Assets/AppsFlyer/IAppsFlyerNativeBridge.cs
+++ b/Assets/AppsFlyer/IAppsFlyerNativeBridge.cs
@@ -8,6 +8,8 @@ namespace AppsFlyerSDK
     public interface IAppsFlyerNativeBridge
     {
         bool isInit { get; set; }
+        
+        void initSDK(string devKey, string appID, MonoBehaviour gameObject);
 
         void startSDK(bool onRequestResponse, string CallBackObjectName);
 


### PR DESCRIPTION
In AppsFlyer.cs script there is a lot instance null checks, which makes code readability and support worse. I suggest to convert instance filed to property and add AppsFlyerDummy instance for editor. Also move initSDK to IAppsFlyerNativeBridge interface makes the code more uniform