### PR TITLE
docs: fix validateAndSendInAppPurchase V2 examples

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1058,13 +1058,12 @@ An af_purchase event with the relevant values will be automatically sent if the 
 
 ```c#
 #if UNITY_ANDROID && !UNITY_EDITOR
-        AFPurchaseDetailsAndroid details = new AFPurchaseDetailsAndroid(AFPurchaseType.Subscription, 
-        "token", "productId");
-        
-        AppsFlyer.validateAndSendInAppPurchase(
-        details, 
-        null, 
-        this);
+        AFPurchaseDetailsAndroid details = new AFPurchaseDetailsAndroid(
+            AFPurchaseType.OneTimePurchase,
+            "purchaseToken",
+            "productId");
+
+        AppsFlyer.validateAndSendInAppPurchase(details, null, this);
 #endif
 ```
 
@@ -1313,12 +1312,12 @@ To send and validate in app purchases you can call this method from the processP
 
 ```c#
 #if UNITY_IOS && !UNITY_EDITOR
-        AFSDKPurchaseDetailsIOS details = AFSDKPurchaseDetailsIOS.Init("productId", "price", "currency",
-        "transactionId");
-        AppsFlyer.validateAndSendInAppPurchase(
-        details, 
-        null, 
-        this);
+        AFSDKPurchaseDetailsIOS details = AFSDKPurchaseDetailsIOS.Init(
+            "productId",
+            "transactionId",
+            AFSDKPurchaseType.OneTimePurchase);
+
+        AppsFlyer.validateAndSendInAppPurchase(details, null, this);
 #endif
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1063,7 +1063,12 @@ An af_purchase event with the relevant values will be automatically sent if the 
             "purchaseToken",
             "productId");
 
-        AppsFlyer.validateAndSendInAppPurchase(details, null, this);
+        var purchaseAdditionalDetails = new Dictionary<string, string>
+        {
+            { "paywall", "123" }
+        };
+
+        AppsFlyer.validateAndSendInAppPurchase(details, purchaseAdditionalDetails, this);
 #endif
 ```
 
@@ -1317,7 +1322,12 @@ To send and validate in app purchases you can call this method from the processP
             "transactionId",
             AFSDKPurchaseType.OneTimePurchase);
 
-        AppsFlyer.validateAndSendInAppPurchase(details, null, this);
+        var purchaseAdditionalDetails = new Dictionary<string, string>
+        {
+            { "paywall", "123" }
+        };
+
+        AppsFlyer.validateAndSendInAppPurchase(details, purchaseAdditionalDetails, this);
 #endif
 ```
 

--- a/docs/InAppEvents.md
+++ b/docs/InAppEvents.md
@@ -144,6 +144,11 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
 
         if (String.Equals(prodID, kProductIDConsumable, StringComparison.Ordinal))
         {
+            var purchaseAdditionalDetails = new Dictionary<string, string>
+            {
+                { "paywall", "123" }
+            };
+
 #if UNITY_IOS
 
             if (isSandbox)
@@ -156,7 +161,7 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
                 transactionID,
                 AFSDKPurchaseType.OneTimePurchase);
 
-            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
+            AppsFlyer.validateAndSendInAppPurchase(details, purchaseAdditionalDetails, this);
 #elif UNITY_ANDROID
 
             var purchaseData = (string)receiptPayload["json"];
@@ -168,7 +173,7 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
                 purchaseToken,
                 prodID);
 
-            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
+            AppsFlyer.validateAndSendInAppPurchase(details, purchaseAdditionalDetails, this);
 #endif
         }
 

--- a/docs/InAppEvents.md
+++ b/docs/InAppEvents.md
@@ -106,15 +106,20 @@ For In-App Purchase Receipt Validation, follow the instructions according to you
 - The validate purchase response is triggered in the `AppsFlyerTrackerCallbacks.cs` class.
 - **iOS Error Handling:** On iOS, the `onValidateAndLogFailure` callback is only triggered for actual errors (network errors, invalid parameters, etc.). Validation failures (e.g., invalid receipt) are returned through the `onValidateAndLogComplete` callback in the response dictionary. Check the response to determine if validation was successful.
 
-```c#
-// for Android 
+**Android**
+
 `void validateAndSendInAppPurchase(AFPurchaseDetailsAndroid details, Dictionary<string, string> additionalParameters, MonoBehaviour gameObject)`
-// for iOS 
+
+**iOS**
+
 `void validateAndSendInAppPurchase(AFSDKPurchaseDetailsIOS details, Dictionary<string, string> extraEventValues, MonoBehaviour gameObject)`
 
-```
+> In the C# SDK, the dictionary parameter is named `purchaseAdditionalDetails` on both platforms.
 
 ```c#
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.Purchasing;
 using AppsFlyerSDK;
 
@@ -125,41 +130,45 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
 
     void Start()
     {
-        AppsFlyer.initSDK("devKey", "devKey");
+        AppsFlyer.initSDK("devKey", "appId");
         AppsFlyer.startSDK();
     }
 
     public PurchaseProcessingResult ProcessPurchase(PurchaseEventArgs args)
     {
         string prodID = args.purchasedProduct.definition.id;
-        string price = args.purchasedProduct.metadata.localizedPrice.ToString();
-        string currency = args.purchasedProduct.metadata.isoCurrencyCode;
+        string transactionID = args.purchasedProduct.transactionID;
 
-        string receipt = args.purchasedProduct.receipt;
-        var recptToJSON = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize(product.receipt);
+        var recptToJSON = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize(args.purchasedProduct.receipt);
         var receiptPayload = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize((string)recptToJSON["Payload"]);
-        var transactionID = product.transactionID;
 
-        if (String.Equals(args.purchasedProduct.definition.id, kProductIDConsumable, StringComparison.Ordinal))
+        if (String.Equals(prodID, kProductIDConsumable, StringComparison.Ordinal))
         {
 #if UNITY_IOS
 
-            if(isSandbox)
+            if (isSandbox)
             {
                 AppsFlyeriOS.setUseReceiptValidationSandbox(true);
             }
 
-            AFSDKPurchaseDetailsIOS details = AFSDKPurchaseDetailsIOS.Init(prodID, price, currency, transactionID);
+            AFSDKPurchaseDetailsIOS details = AFSDKPurchaseDetailsIOS.Init(
+                prodID,
+                transactionID,
+                AFSDKPurchaseType.OneTimePurchase);
 
-            AppsFlyeriOS.validateAndSendInAppPurchase(details, null, this);
+            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
 #elif UNITY_ANDROID
 
-        AFPurchaseDetailsAndroid details = new AFPurchaseDetailsAndroid(AFPurchaseType.Subscription, "token", prodID, price, currency);
+            var purchaseData = (string)receiptPayload["json"];
+            var purchaseDataJson = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize(purchaseData);
+            string purchaseToken = (string)purchaseDataJson["purchaseToken"];
 
-        AppsFlyerAndroid.validateAndSendInAppPurchase(
-        details,
-        null, 
-        this);
+            AFPurchaseDetailsAndroid details = new AFPurchaseDetailsAndroid(
+                AFPurchaseType.OneTimePurchase,
+                purchaseToken,
+                prodID);
+
+            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
 #endif
         }
 

--- a/docs/validate-and-log-unity.md
+++ b/docs/validate-and-log-unity.md
@@ -15,15 +15,22 @@ Follow the instructions according to your operating system.
 Calling `validateAndSendInAppPurchase` automatically generates an `af_purchase` in-app event, so you don't need to send this event yourself.
 The validate purchase response is triggered in the `AppsFlyerTrackerCallbacks.cs` class.
 
-```c#
-// for Android 
+**Android**
+
 `void validateAndSendInAppPurchase(AFPurchaseDetailsAndroid details, Dictionary<string, string> additionalParameters, MonoBehaviour gameObject)`
-// for iOS 
+
+**iOS**
+
 `void validateAndSendInAppPurchase(AFSDKPurchaseDetailsIOS details, Dictionary<string, string> extraEventValues, MonoBehaviour gameObject)`
 
-```
+> In the C# SDK, the dictionary parameter is named `purchaseAdditionalDetails` on both platforms.
+
+Use `AFPurchaseType` / `AFSDKPurchaseType` (`OneTimePurchase` or `Subscription`) to match the product. On iOS, call `setUseReceiptValidationSandbox(true)` before validation when testing in the sandbox.
 
 ```c#
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.Purchasing;
 using AppsFlyerSDK;
 
@@ -34,41 +41,45 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
 
     void Start()
     {
-        AppsFlyer.initSDK("devKey", "devKey");
+        AppsFlyer.initSDK("devKey", "appId");
         AppsFlyer.startSDK();
     }
 
     public PurchaseProcessingResult ProcessPurchase(PurchaseEventArgs args)
     {
         string prodID = args.purchasedProduct.definition.id;
-        string price = args.purchasedProduct.metadata.localizedPrice.ToString();
-        string currency = args.purchasedProduct.metadata.isoCurrencyCode;
+        string transactionID = args.purchasedProduct.transactionID;
 
-        string receipt = args.purchasedProduct.receipt;
-        var recptToJSON = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize(product.receipt);
+        var recptToJSON = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize(args.purchasedProduct.receipt);
         var receiptPayload = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize((string)recptToJSON["Payload"]);
-        var transactionID = product.transactionID;
 
-        if (String.Equals(args.purchasedProduct.definition.id, kProductIDConsumable, StringComparison.Ordinal))
+        if (String.Equals(prodID, kProductIDConsumable, StringComparison.Ordinal))
         {
 #if UNITY_IOS
 
-            if(isSandbox)
+            if (isSandbox)
             {
                 AppsFlyeriOS.setUseReceiptValidationSandbox(true);
             }
 
-            AFSDKPurchaseDetailsIOS details = AFSDKPurchaseDetailsIOS.Init(prodID, price, currency, transactionID);
+            AFSDKPurchaseDetailsIOS details = AFSDKPurchaseDetailsIOS.Init(
+                prodID,
+                transactionID,
+                AFSDKPurchaseType.OneTimePurchase);
 
-            AppsFlyeriOS.validateAndSendInAppPurchase(details, null, this);
+            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
 #elif UNITY_ANDROID
 
-        AFPurchaseDetailsAndroid details = new AFPurchaseDetailsAndroid(AFPurchaseType.Subscription, "token", prodID, price, currency);
+            var purchaseData = (string)receiptPayload["json"];
+            var purchaseDataJson = (Dictionary<string, object>)AFMiniJSON.Json.Deserialize(purchaseData);
+            string purchaseToken = (string)purchaseDataJson["purchaseToken"];
 
-        AppsFlyerAndroid.validateAndSendInAppPurchase(
-        details,
-        null, 
-        this);
+            AFPurchaseDetailsAndroid details = new AFPurchaseDetailsAndroid(
+                AFPurchaseType.OneTimePurchase,
+                purchaseToken,
+                prodID);
+
+            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
 #endif
         }
 
@@ -94,6 +105,7 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
 ## Receipt validation [Legacy]
 <span class="annotation-deprecated">Deprecated since V6.17.8</span>  
 
+For current integration, use the [Validate and log purchase](#validate-and-log-purchase) section above.
 
 For Receipt Validation, follow the instructions according to your operating system.
 

--- a/docs/validate-and-log-unity.md
+++ b/docs/validate-and-log-unity.md
@@ -55,6 +55,11 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
 
         if (String.Equals(prodID, kProductIDConsumable, StringComparison.Ordinal))
         {
+            var purchaseAdditionalDetails = new Dictionary<string, string>
+            {
+                { "paywall", "123" }
+            };
+
 #if UNITY_IOS
 
             if (isSandbox)
@@ -67,7 +72,7 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
                 transactionID,
                 AFSDKPurchaseType.OneTimePurchase);
 
-            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
+            AppsFlyer.validateAndSendInAppPurchase(details, purchaseAdditionalDetails, this);
 #elif UNITY_ANDROID
 
             var purchaseData = (string)receiptPayload["json"];
@@ -79,7 +84,7 @@ public class AppsFlyerObject : MonoBehaviour, IAppsFlyerValidateAndLog
                 purchaseToken,
                 prodID);
 
-            AppsFlyer.validateAndSendInAppPurchase(details, null, this);
+            AppsFlyer.validateAndSendInAppPurchase(details, purchaseAdditionalDetails, this);
 #endif
         }
 


### PR DESCRIPTION
Update purchase validation docs to use correct V2 constructors and pass null for optional additional parameters instead of legacy-style detail object fields.