### PR TITLE
ci: add RC release + E2E workflows to master

### DIFF
--- a/.github/workflows/e2e-android-only.yml
+++ b/.github/workflows/e2e-android-only.yml
@@ -1,0 +1,12 @@
+name: E2E — Android only
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e-android:
+    uses: ./.github/workflows/rc-e2e-android.yml
+    with:
+      plugin_version: ${{ github.event.inputs.plugin_version || 'push-trigger' }}
+      release_branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/e2e-ios-only.yml
+++ b/.github/workflows/e2e-ios-only.yml
@@ -1,0 +1,17 @@
+name: E2E — iOS only
+
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e-ios:
+    strategy:
+      matrix:
+        run: [1, 2, 3]
+      fail-fast: false
+      max-parallel: 1
+    uses: ./.github/workflows/rc-e2e-ios.yml
+    with:
+      plugin_version: stability-run-${{ matrix.run }}
+      release_branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -1,0 +1,35 @@
+name: E2E — Manual trigger
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin_version:
+        description: Version label for the report (e.g. 6.18.0-rc1)
+        required: false
+        default: manual-test
+      platform:
+        description: Platform to test
+        required: true
+        type: choice
+        options:
+          - both
+          - android
+          - ios
+        default: both
+
+jobs:
+  e2e-android:
+    if: ${{ (inputs.platform || 'both') == 'both' || (inputs.platform || 'both') == 'android' }}
+    uses: ./.github/workflows/rc-e2e-android.yml
+    with:
+      plugin_version: ${{ inputs.plugin_version || 'push-trigger' }}
+      release_branch: ${{ github.ref_name }}
+    secrets: inherit
+
+  e2e-ios:
+    if: ${{ (inputs.platform || 'both') == 'both' || (inputs.platform || 'both') == 'ios' }}
+    uses: ./.github/workflows/rc-e2e-ios.yml
+    with:
+      plugin_version: ${{ inputs.plugin_version || 'push-trigger' }}
+      release_branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,69 @@
+name: RC-PROMOTE — Strip -rcN and prepare for merge
+
+# Triggered when a maintainer applies the "pass QA ready for deploy" label
+# to the release PR targeting master.
+on:
+  pull_request:
+    types: [labeled]
+    branches: [master]
+
+jobs:
+  promote:
+    name: RC-PROMOTE
+    if: |
+      github.event.label.name == 'pass QA ready for deploy' &&
+      startsWith(github.event.pull_request.head.ref, 'releases/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref:        ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token:      ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "${{ secrets.CI_USERNAME }}"
+          git config user.email "${{ secrets.CI_EMAIL }}"
+
+      - name: Extract base version (strip -rcN)
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          # Branch pattern: releases/6.x.x/18.x/6.18.0-rc1
+          BASE=$(echo "$BRANCH" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?' | tail -1 | sed 's/-rc[0-9]*$//')
+          echo "base_version=$BASE" >> "$GITHUB_OUTPUT"
+          echo "Promoting to: $BASE"
+
+      - name: Strip -rcN from all version surfaces
+        run: |
+          BASE="${{ steps.version.outputs.base_version }}"
+          for f in \
+            Assets/AppsFlyer/package.json \
+            Assets/AppsFlyer/AppsFlyer.cs \
+            deploy/build_unity_package.sh \
+            deploy/strict_mode_build_package.sh; do
+            [[ -f "$f" ]] && sed -i "s/-rc[0-9]*//g" "$f" && echo "Stripped: $f"
+          done
+
+      - name: Commit and push
+        run: |
+          BASE="${{ steps.version.outputs.base_version }}"
+          git add \
+            Assets/AppsFlyer/package.json \
+            Assets/AppsFlyer/AppsFlyer.cs \
+            deploy/build_unity_package.sh \
+            deploy/strict_mode_build_package.sh || true
+          git diff --cached --quiet && echo "Nothing to commit" && exit 0
+          git commit -m "chore: promote to $BASE — strip -rcN"
+          git push origin "${{ github.event.pull_request.head.ref }}"
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="${{ steps.version.outputs.base_version }}"
+          gh pr comment "${{ github.event.pull_request.number }}" --body \
+            "✅ **RC-PROMOTE complete** — version surfaces updated to \`$BASE\`. Branch is ready to merge."

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -1,0 +1,107 @@
+name: RC E2E — Android (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      plugin_version:
+        description: RC plugin version (e.g. 6.18.0-rc1)
+        required: true
+        type: string
+      release_branch:
+        description: Release branch to check out
+        required: true
+        type: string
+    secrets:
+      UNITY_EMAIL:
+        required: true
+      UNITY_PASSWORD:
+        required: true
+      UNITY_SERIAL:
+        required: true
+      ENV_FILE:
+        required: true
+
+jobs:
+  e2e-android:
+    name: E2E Android — ${{ inputs.plugin_version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+
+      - name: Write .env from secret
+        run: |
+          printf '%s' "${{ secrets.ENV_FILE }}" > test-app/Assets/StreamingAssets/.env
+
+      - name: Activate Unity license
+        uses: game-ci/unity-activate@v2
+        env:
+          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+
+      - name: Build Android APK (via Unity)
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+        with:
+          projectPath:      test-app
+          unityVersion:     6000.3.5f1
+          targetPlatform:   Android
+          buildName:        com.appsflyer.engagement
+          buildsPath:       test-app/Build
+          buildMethod:      BuildScript.BuildAndroid
+          androidExportType: androidPackage
+          allowDirtyBuild:  true
+
+      - name: Locate APK
+        run: |
+          APK=$(find test-app/Build/Android -name "*.apk" | head -1)
+          if [[ -z "$APK" ]]; then
+            echo "::error::APK not found after Unity build"
+            exit 1
+          fi
+          echo "APK_PATH=$APK" >> "$GITHUB_ENV"
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Enable KVM for hardware-accelerated emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run E2E scenario runner inside Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level:   31
+          arch:        x86_64
+          profile:     Nexus 6
+          avd-name:    e2e_avd
+          emulator-options: -no-snapshot -no-window -no-boot-anim -gpu swiftshader_indirect
+          disable-animations: true
+          script: |
+            adb wait-for-device
+            adb install -r "${{ env.APK_PATH }}"
+            adb shell am force-stop com.appsflyer.engagement
+            chmod +x scripts/af-scenario-runner.sh
+            scripts/af-scenario-runner.sh --platform android --plan .af-e2e/test-plan.json --verbose
+
+      - name: Upload E2E report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-android-report-${{ inputs.plugin_version }}
+          path: .af-e2e/reports/
+          retention-days: 30
+
+      - name: Return Unity license
+        if: always()
+        uses: game-ci/unity-return-license@v2

--- a/.github/workflows/rc-e2e-ios.yml
+++ b/.github/workflows/rc-e2e-ios.yml
@@ -1,0 +1,170 @@
+name: RC E2E — iOS (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      plugin_version:
+        description: RC plugin version (e.g. 6.18.0-rc1)
+        required: true
+        type: string
+      release_branch:
+        description: Release branch to check out
+        required: true
+        type: string
+    secrets:
+      UNITY_EMAIL:
+        required: true
+      UNITY_PASSWORD:
+        required: true
+      UNITY_SERIAL:
+        required: true
+      ENV_FILE:
+        required: true
+
+jobs:
+  e2e-ios:
+    name: E2E iOS — ${{ inputs.plugin_version }}
+    runs-on: macos-14
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_branch }}
+
+      - name: Write .env from secret
+        run: |
+          printf '%s' "${{ secrets.ENV_FILE }}" > test-app/Assets/StreamingAssets/.env
+
+      - name: Cache Unity Editor installation
+        id: cache-unity
+        uses: actions/cache@v4
+        with:
+          path: /Applications/Unity/Unity.app
+          key: unity-6000.3.5f1-ios-macos14-arm64
+
+      - name: Install Unity Editor + iOS module
+        if: steps.cache-unity.outputs.cache-hit != 'true'
+        run: |
+          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/MacEditorInstallerArm64/Unity-6000.3.5f1.pkg" \
+            -o /tmp/Unity.pkg
+          sudo installer -pkg /tmp/Unity.pkg -target /
+          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-6000.3.5f1.pkg" \
+            -o /tmp/Unity-iOS.pkg
+          sudo installer -pkg /tmp/Unity-iOS.pkg -target /
+          UNITY=$(find /Applications -name "Unity" -type f -path "*/MacOS/Unity" 2>/dev/null | head -1)
+          echo "Unity installed at: $UNITY"
+          echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
+        timeout-minutes: 60
+
+      - name: Activate Unity license
+        run: |
+          UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"
+          "$UNITY" -quit -batchmode \
+            -serial "${{ secrets.UNITY_SERIAL }}" \
+            -username "${{ secrets.UNITY_EMAIL }}" \
+            -password "${{ secrets.UNITY_PASSWORD }}" \
+            -logFile /tmp/unity-activate.log 2>&1 || true
+          grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
+
+      - name: Build iOS Simulator Xcode project
+        run: |
+          UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"
+          mkdir -p test-app/Build/iOS-Simulator
+          "$UNITY" -quit -batchmode \
+            -logFile /tmp/unity-build.log \
+            -projectPath "$(pwd)/test-app" \
+            -buildTarget iOS \
+            -executeMethod BuildScript.BuildIOSSimulator
+          BUILD_EXIT=$?
+          tail -50 /tmp/unity-build.log
+          exit $BUILD_EXIT
+        timeout-minutes: 30
+
+      - name: Patch Unity libs to arm64 simulator
+        run: |
+          TRAMPOLINE=$(find /Applications/Unity -name "baselib-sim-arm64.a" 2>/dev/null | head -1 | sed 's|/Libraries/baselib-sim-arm64.a||')
+          if [[ -z "$TRAMPOLINE" ]]; then
+            echo "::error::baselib-sim-arm64.a not found under /Applications/Unity"
+            find /Applications/Unity -name "PlaybackEngines" -type d 2>/dev/null | head -5
+            exit 1
+          fi
+          echo "Trampoline: $TRAMPOLINE"
+          cp "$TRAMPOLINE/Libraries/baselib-sim-arm64.a" \
+             test-app/Build/iOS-Simulator/Libraries/baselib.a
+          cp "$TRAMPOLINE/Frameworks/libiPhone-lib-sim-arm64/UnityRuntime.framework/UnityRuntime" \
+             test-app/Build/iOS-Simulator/Frameworks/UnityRuntime.framework/UnityRuntime
+          echo "Patched to arm64 simulator"
+
+      - name: Return Unity license
+        if: always()
+        run: |
+          UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"
+          "$UNITY" -quit -batchmode -returnlicense \
+            -logFile /tmp/unity-return.log 2>&1 || true
+
+      - name: Install iOS pods
+        run: |
+          chmod +x scripts/ios-pod-install.sh
+          scripts/ios-pod-install.sh test-app/Build/iOS-Simulator
+
+      - name: Compile simulator .app from Xcode workspace
+        run: |
+          XCODE_WS=test-app/Build/iOS-Simulator/Unity-iPhone.xcworkspace
+          xcodebuild \
+            -workspace "$XCODE_WS" \
+            -scheme    Unity-iPhone \
+            -sdk       iphonesimulator \
+            -configuration Debug \
+            -derivedDataPath test-app/Build/iOS-Simulator/DerivedData \
+            ARCHS=arm64 \
+            VALID_ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=NO \
+            CURRENT_PROJECT_VERSION=1 \
+            MARKETING_VERSION=1.0 \
+            ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=YES \
+            build 2>&1 | tee /tmp/xcode-build.log | xcpretty || true
+          if grep -q "\*\* BUILD FAILED \*\*" /tmp/xcode-build.log; then
+            echo "::group::xcodebuild errors"
+            grep -A 30 "Undefined symbols" /tmp/xcode-build.log || true
+            grep -E "^(ld: |clang: error: |error: )" /tmp/xcode-build.log | head -40 || true
+            echo "::endgroup::"
+            exit 1
+          fi
+          APP=$(find test-app/Build/iOS-Simulator/DerivedData -name "UnityQATest.app" -maxdepth 6 | head -1)
+          if [[ -z "$APP" ]]; then
+            echo "::error::UnityQATest.app not found after xcodebuild"
+            exit 1
+          fi
+          rm -rf test-app/Build/iOS-Simulator/UnityQATest.app
+          cp -R "$APP" test-app/Build/iOS-Simulator/UnityQATest.app
+
+      - name: Boot iOS simulator
+        run: |
+          UDID=$(xcrun simctl list devices available -j | \
+            jq -r '.devices | to_entries[] | select(.key | contains("iOS-18")) | .value[] | select(.isAvailable == true) | .udid' | head -1)
+          if [[ -z "$UDID" ]]; then
+            UDID=$(xcrun simctl list devices available -j | \
+              jq -r '.devices[][] | select(.isAvailable == true) | .udid' | head -1)
+          fi
+          echo "Booting simulator: $UDID"
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
+          echo "SIM_UDID=$UDID" >> "$GITHUB_ENV"
+
+      - name: Run E2E scenario runner — iOS
+        run: |
+          chmod +x scripts/af-scenario-runner.sh
+          scripts/af-scenario-runner.sh \
+            --platform ios \
+            --plan     .af-e2e/test-plan.json \
+            --verbose
+
+      - name: Upload E2E report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-ios-report-${{ inputs.plugin_version }}
+          path: .af-e2e/reports/
+          retention-days: 30

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -1,0 +1,120 @@
+name: RC Release Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin_version:
+        description: "Plugin version — e.g. 6.18.0-rc1"
+        required: true
+        type: string
+      android_sdk_version:
+        description: "Android SDK version — e.g. 6.18.0"
+        required: true
+        type: string
+      ios_sdk_version:
+        description: "iOS SDK version — e.g. 6.18.0"
+        required: true
+        type: string
+      base_branch:
+        description: "Branch to cut the release from (default: development)"
+        required: false
+        default: development
+        type: string
+
+jobs:
+  # ── 1. Prepare release branch ───────────────────────────────────────────────
+  prepare-branch:
+    name: Prepare release branch
+    runs-on: ubuntu-latest
+    outputs:
+      release_branch: ${{ steps.branch.outputs.release_branch }}
+
+    steps:
+      - name: Validate plugin_version format
+        run: |
+          if ! echo "${{ github.event.inputs.plugin_version }}" | grep -qE '^\d+\.\d+\.\d+-rc\d+$'; then
+            echo "::error::plugin_version must match X.Y.Z-rcN (e.g. 6.18.0-rc1)"
+            exit 1
+          fi
+
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref:         ${{ github.event.inputs.base_branch }}
+          fetch-depth: 0
+          token:       ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name  "${{ secrets.CI_USERNAME }}"
+          git config user.email "${{ secrets.CI_EMAIL }}"
+
+      - name: Derive release branch name
+        id: branch
+        run: |
+          VERSION="${{ github.event.inputs.plugin_version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          BRANCH="releases/${MAJOR}.x.x/${MINOR}.x/${VERSION}"
+          echo "release_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "release_branch=$BRANCH"
+
+      - name: Create or reset release branch
+        run: |
+          BRANCH="${{ steps.branch.outputs.release_branch }}"
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "Branch exists — resetting to ${{ github.event.inputs.base_branch }}"
+            git checkout -B "$BRANCH" "origin/${{ github.event.inputs.base_branch }}"
+          else
+            echo "Creating branch: $BRANCH"
+            git checkout -b "$BRANCH"
+          fi
+
+      - name: Bump versions
+        run: |
+          chmod +x scripts/bump-version.sh
+          scripts/bump-version.sh \
+            --plugin-version        "${{ github.event.inputs.plugin_version }}" \
+            --android-sdk-version   "${{ github.event.inputs.android_sdk_version }}" \
+            --ios-sdk-version       "${{ github.event.inputs.ios_sdk_version }}"
+
+      - name: Commit and push
+        run: |
+          git add \
+            Assets/AppsFlyer/package.json \
+            Assets/AppsFlyer/AppsFlyer.cs \
+            Assets/AppsFlyer/Editor/AppsFlyerDependencies.xml \
+            deploy/build_unity_package.sh \
+            deploy/strict_mode_build_package.sh \
+            CHANGELOG.md \
+            README.md
+          git commit -m "chore: bump to ${{ github.event.inputs.plugin_version }}" || echo "Nothing to commit"
+          git push origin "${{ steps.branch.outputs.release_branch }}" --force
+
+  # ── 2. E2E — iOS ────────────────────────────────────────────────────────────
+  run-e2e-ios:
+    name: E2E — iOS
+    needs: prepare-branch
+    uses: ./.github/workflows/rc-e2e-ios.yml
+    with:
+      plugin_version: ${{ github.event.inputs.plugin_version }}
+      release_branch: ${{ needs.prepare-branch.outputs.release_branch }}
+    secrets:
+      UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+      UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+      UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+      ENV_FILE:       ${{ secrets.ENV_FILE }}
+
+  # ── 3. E2E — Android (after iOS to avoid Unity license contention) ──────────
+  run-e2e-android:
+    name: E2E — Android
+    needs: [prepare-branch, run-e2e-ios]
+    uses: ./.github/workflows/rc-e2e-android.yml
+    with:
+      plugin_version: ${{ github.event.inputs.plugin_version }}
+      release_branch: ${{ needs.prepare-branch.outputs.release_branch }}
+    secrets:
+      UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+      UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+      UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+      ENV_FILE:       ${{ secrets.ENV_FILE }}


### PR DESCRIPTION
## Summary

Adds the RC release and E2E workflow files to `master` (the default branch) so `workflow_dispatch` triggers are available in the GitHub UI.

**No source code changes** — only `.github/workflows/` files. All scripts and source files are on `development` and get pulled when the workflow checks out the release branch.

## Workflows added
- `rc-release.yml` — RC Release Pipeline: takes version inputs, cuts release branch from `development`, bumps versions, runs iOS + Android E2E
- `rc-e2e-ios.yml` — reusable iOS E2E (macos-14)
- `rc-e2e-android.yml` — reusable Android E2E (ubuntu-latest)
- `promote-release.yml` — RC-PROMOTE via label
- `e2e-ios-only.yml`, `e2e-android-only.yml`, `e2e-manual.yml` — ad-hoc triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)