### PR TITLE
fix: Linux grep-E \d regex in rc-release validation

### DIFF
--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Validate plugin_version format
         run: |
-          if ! echo "${{ github.event.inputs.plugin_version }}" | grep -qE '^\d+\.\d+\.\d+-rc\d+$'; then
+          if ! echo "${{ github.event.inputs.plugin_version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'; then
             echo "::error::plugin_version must match X.Y.Z-rcN (e.g. 6.18.0-rc1)"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Replaces `\d` with `[0-9]` in the `plugin_version` format validation step
- `\d` is a Perl-style shorthand not supported by Linux `grep -E` (POSIX ERE), which caused the validation to always fail on `ubuntu-latest` runners
- No logic change — same pattern, just POSIX-compatible syntax

## Repro
Run `26043050097` failed immediately at "Validate plugin_version format" with exit 1 even though `6.18.0-rc1` is a valid version.

## Test plan
- [ ] Trigger RC Release Pipeline from master with `plugin_version=6.18.0-rc1` — validation should pass