### PR TITLE
fix: pass credentials to Unity returnlicense and surface return log

### DIFF
--- a/.github/workflows/rc-e2e-ios.yml
+++ b/.github/workflows/rc-e2e-ios.yml
@@ -61,11 +61,31 @@ jobs:
       - name: Activate Unity license
         run: |
           UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"
-          "$UNITY" -quit -batchmode \
-            -serial "${{ secrets.UNITY_SERIAL }}" \
-            -username "${{ secrets.UNITY_EMAIL }}" \
-            -password "${{ secrets.UNITY_PASSWORD }}" \
-            -logFile /tmp/unity-activate.log 2>&1 || true
+
+          activate() {
+            rm -f /tmp/unity-activate.log
+            "$UNITY" -quit -batchmode \
+              -serial   "${{ secrets.UNITY_SERIAL }}" \
+              -username "${{ secrets.UNITY_EMAIL }}" \
+              -password "${{ secrets.UNITY_PASSWORD }}" \
+              -logFile  /tmp/unity-activate.log 2>&1 || true
+          }
+
+          activate
+
+          if grep -q "serial has reached the maximum number of activations" /tmp/unity-activate.log 2>/dev/null; then
+            echo "::warning::Serial at max activations — returning existing license and retrying in 60s..."
+            "$UNITY" -quit -batchmode -returnlicense \
+              -username "${{ secrets.UNITY_EMAIL }}" \
+              -password "${{ secrets.UNITY_PASSWORD }}" \
+              -serial   "${{ secrets.UNITY_SERIAL }}" \
+              -logFile  /tmp/unity-return-preflight.log 2>&1 || true
+            echo "=== preflight return log ==="
+            cat /tmp/unity-return-preflight.log || true
+            sleep 60
+            activate
+          fi
+
           grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
 
       - name: Build iOS Simulator Xcode project

--- a/.github/workflows/rc-e2e-ios.yml
+++ b/.github/workflows/rc-e2e-ios.yml
@@ -102,7 +102,12 @@ jobs:
         run: |
           UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"
           "$UNITY" -quit -batchmode -returnlicense \
+            -username "${{ secrets.UNITY_EMAIL }}" \
+            -password "${{ secrets.UNITY_PASSWORD }}" \
+            -serial   "${{ secrets.UNITY_SERIAL }}" \
             -logFile /tmp/unity-return.log 2>&1 || true
+          echo "=== unity-return.log ==="
+          cat /tmp/unity-return.log || true
 
       - name: Install iOS pods
         run: |


### PR DESCRIPTION
## Summary
- Adds `-username`, `-password`, `-serial` flags to the `returnlicense` command in the iOS E2E job
- Without credentials the command failed in ~1 second silently (swallowed by `|| true`), leaving the serial seat occupied
- This caused Android's `game-ci/unity-activate` to hit `serial has reached the maximum number of activations` even though iOS had already finished
- Also adds `cat /tmp/unity-return.log` so the return result is visible in CI logs

## Test plan
- [ ] Merge and trigger RC Release Pipeline — check "Return Unity license" step takes >5s and shows a success message in the log
- [ ] Android activation should succeed after iOS completes