### PR TITLE
fix: remove -serial from Unity returnlicense (incompatible flags)

### DIFF
--- a/.github/workflows/rc-e2e-ios.yml
+++ b/.github/workflows/rc-e2e-ios.yml
@@ -78,7 +78,6 @@ jobs:
             "$UNITY" -quit -batchmode -returnlicense \
               -username "${{ secrets.UNITY_EMAIL }}" \
               -password "${{ secrets.UNITY_PASSWORD }}" \
-              -serial   "${{ secrets.UNITY_SERIAL }}" \
               -logFile  /tmp/unity-return-preflight.log 2>&1 || true
             echo "=== preflight return log ==="
             cat /tmp/unity-return-preflight.log || true
@@ -124,7 +123,6 @@ jobs:
           "$UNITY" -quit -batchmode -returnlicense \
             -username "${{ secrets.UNITY_EMAIL }}" \
             -password "${{ secrets.UNITY_PASSWORD }}" \
-            -serial   "${{ secrets.UNITY_SERIAL }}" \
             -logFile /tmp/unity-return.log 2>&1 || true
           echo "=== unity-return.log ==="
           cat /tmp/unity-return.log || true


### PR DESCRIPTION
## Summary
- Removes `-serial` flag from both `returnlicense` calls in the iOS E2E workflow
- Unity errors with `-serial and -returnLicense cannot be used simultaneously`
- This was preventing the license from being returned, leaving the seat occupied and causing Android activation to fail with max activations

## Test plan
- [ ] Merge and trigger RC Release Pipeline — iOS return log should show success, Android should activate cleanly