### PR TITLE
fix: remove game-ci activate/return-license from Android E2E workflow

### DIFF
--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -37,13 +37,6 @@ jobs:
         run: |
           printf '%s' "${{ secrets.ENV_FILE }}" > test-app/Assets/StreamingAssets/.env
 
-      - name: Activate Unity license
-        uses: game-ci/unity-activate@v2
-        env:
-          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
-
       - name: Build Android APK (via Unity)
         uses: game-ci/unity-builder@v4
         env:
@@ -59,6 +52,28 @@ jobs:
           buildMethod:      BuildScript.BuildAndroid
           androidExportType: androidPackage
           allowDirtyBuild:  true
+
+      - name: Return Unity license
+        if: always()
+        run: |
+          docker run --rm \
+            --env UNITY_EMAIL \
+            --env UNITY_PASSWORD \
+            --env UNITY_SERIAL \
+            --env HOME=/root \
+            unityci/editor:ubuntu-6000.3.5f1-android-3 \
+            bash -c "
+              unity-editor -quit -batchmode -returnlicense \
+                -username \"\$UNITY_EMAIL\" \
+                -password \"\$UNITY_PASSWORD\" \
+                -logFile /tmp/unity-return.log 2>&1 || true
+              echo '=== unity-return.log ==='
+              cat /tmp/unity-return.log || true
+            " || true
+        env:
+          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
 
       - name: Locate APK
         run: |
@@ -101,7 +116,3 @@ jobs:
           name: e2e-android-report-${{ inputs.plugin_version }}
           path: .af-e2e/reports/
           retention-days: 30
-
-      - name: Return Unity license
-        if: always()
-        uses: game-ci/unity-return-license@v2


### PR DESCRIPTION
## Summary

- Removes `game-ci/unity-activate@v2` — `unity-builder@v4` handles activation internally, so the extra activate step was consuming a second license seat unnecessarily
- Removes `game-ci/unity-return-license@v2` — this action fails with "No UNITY_SERIAL detected" and leaves seats permanently stuck
- Adds explicit Docker-based return step using the same `unityci/editor:ubuntu-6000.3.5f1-android-3` image that the builder uses — confirmed working (seat visible in Unity portal, then removed after run)

## Test plan

- [x] Android E2E run passed end-to-end on `plugins-effort-reduction-workflow1` branch
- [x] License was visible in Unity portal during build and removed after the return step
- [ ] Run full RC pipeline (`rc-release.yml`) to confirm iOS → Android sequential run with no seat contention

🤖 Generated with [Claude Code](https://claude.com/claude-code)