### PR TITLE
fix: bump-version.sh must also patch test-app gradle and ios-pod-install

### DIFF
--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -105,3 +105,5 @@ jobs:
       - name: Return Unity license
         if: always()
         uses: game-ci/unity-return-license@v2
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -37,59 +37,21 @@ jobs:
         run: |
           printf '%s' "${{ secrets.ENV_FILE }}" > test-app/Assets/StreamingAssets/.env
 
-      - name: Cache Unity Editor installation
-        id: cache-unity
-        uses: actions/cache@v4
+      - name: Build Android APK (via Unity)
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
         with:
-          path: /opt/unity
-          key: unity-6000.3.5f1-android-ubuntu
-
-      - name: Install Unity Editor + Android module
-        if: steps.cache-unity.outputs.cache-hit != 'true'
-        run: |
-          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/LinuxEditorInstaller/Unity-6000.3.5f1.tar.xz" \
-            -o /tmp/Unity.tar.xz
-          sudo mkdir -p /opt/unity
-          sudo tar -xf /tmp/Unity.tar.xz -C /opt/unity
-          UNITY=$(find /opt/unity -name "Unity" -type f -path "*/Editor/Unity" 2>/dev/null | head -1)
-          echo "Unity installed at: $UNITY"
-          echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
-        timeout-minutes: 60
-
-      - name: Activate Unity license
-        run: |
-          UNITY="${UNITY_PATH:-/opt/unity/Editor/Unity}"
-          "$UNITY" -quit -batchmode \
-            -serial   "${{ secrets.UNITY_SERIAL }}" \
-            -username "${{ secrets.UNITY_EMAIL }}" \
-            -password "${{ secrets.UNITY_PASSWORD }}" \
-            -logFile  /tmp/unity-activate.log 2>&1 || true
-          grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
-
-      - name: Build Android APK
-        run: |
-          UNITY="${UNITY_PATH:-/opt/unity/Editor/Unity}"
-          mkdir -p test-app/Build/Android
-          "$UNITY" -quit -batchmode \
-            -logFile /tmp/unity-build.log \
-            -projectPath "$(pwd)/test-app" \
-            -buildTarget Android \
-            -executeMethod BuildScript.BuildAndroid
-          BUILD_EXIT=$?
-          tail -50 /tmp/unity-build.log
-          exit $BUILD_EXIT
-        timeout-minutes: 30
-
-      - name: Return Unity license
-        if: always()
-        run: |
-          UNITY="${UNITY_PATH:-/opt/unity/Editor/Unity}"
-          "$UNITY" -quit -batchmode -returnlicense \
-            -username "${{ secrets.UNITY_EMAIL }}" \
-            -password "${{ secrets.UNITY_PASSWORD }}" \
-            -logFile  /tmp/unity-return.log 2>&1 || true
-          echo "=== unity-return.log ==="
-          cat /tmp/unity-return.log || true
+          projectPath:      test-app
+          unityVersion:     6000.3.5f1
+          targetPlatform:   Android
+          buildName:        com.appsflyer.engagement
+          buildsPath:       test-app/Build
+          buildMethod:      BuildScript.BuildAndroid
+          androidExportType: androidPackage
+          allowDirtyBuild:  true
 
       - name: Locate APK
         run: |

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -37,28 +37,62 @@ jobs:
         run: |
           printf '%s' "${{ secrets.ENV_FILE }}" > test-app/Assets/StreamingAssets/.env
 
-      - name: Activate Unity license
-        uses: game-ci/unity-activate@v2
-        env:
-          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
-
-      - name: Build Android APK (via Unity)
-        uses: game-ci/unity-builder@v4
-        env:
-          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+      - name: Cache Unity Editor installation
+        id: cache-unity
+        uses: actions/cache@v4
         with:
-          projectPath:      test-app
-          unityVersion:     6000.3.5f1
-          targetPlatform:   Android
-          buildName:        com.appsflyer.engagement
-          buildsPath:       test-app/Build
-          buildMethod:      BuildScript.BuildAndroid
-          androidExportType: androidPackage
-          allowDirtyBuild:  true
+          path: /opt/unity
+          key: unity-6000.3.5f1-android-ubuntu
+
+      - name: Install Unity Editor + Android module
+        if: steps.cache-unity.outputs.cache-hit != 'true'
+        run: |
+          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/LinuxEditorInstaller/Unity-6000.3.5f1.tar.xz" \
+            -o /tmp/Unity.tar.xz
+          sudo mkdir -p /opt/unity
+          sudo tar -xf /tmp/Unity.tar.xz -C /opt/unity
+          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/LinuxEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-6000.3.5f1.tar.xz" \
+            -o /tmp/Unity-Android.tar.xz
+          sudo tar -xf /tmp/Unity-Android.tar.xz -C /opt/unity
+          UNITY=$(find /opt/unity -name "Unity" -type f -path "*/Editor/Unity" 2>/dev/null | head -1)
+          echo "Unity installed at: $UNITY"
+          echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
+        timeout-minutes: 60
+
+      - name: Activate Unity license
+        run: |
+          UNITY="${UNITY_PATH:-/opt/unity/Editor/Unity}"
+          "$UNITY" -quit -batchmode \
+            -serial   "${{ secrets.UNITY_SERIAL }}" \
+            -username "${{ secrets.UNITY_EMAIL }}" \
+            -password "${{ secrets.UNITY_PASSWORD }}" \
+            -logFile  /tmp/unity-activate.log 2>&1 || true
+          grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
+
+      - name: Build Android APK
+        run: |
+          UNITY="${UNITY_PATH:-/opt/unity/Editor/Unity}"
+          mkdir -p test-app/Build/Android
+          "$UNITY" -quit -batchmode \
+            -logFile /tmp/unity-build.log \
+            -projectPath "$(pwd)/test-app" \
+            -buildTarget Android \
+            -executeMethod BuildScript.BuildAndroid
+          BUILD_EXIT=$?
+          tail -50 /tmp/unity-build.log
+          exit $BUILD_EXIT
+        timeout-minutes: 30
+
+      - name: Return Unity license
+        if: always()
+        run: |
+          UNITY="${UNITY_PATH:-/opt/unity/Editor/Unity}"
+          "$UNITY" -quit -batchmode -returnlicense \
+            -username "${{ secrets.UNITY_EMAIL }}" \
+            -password "${{ secrets.UNITY_PASSWORD }}" \
+            -logFile  /tmp/unity-return.log 2>&1 || true
+          echo "=== unity-return.log ==="
+          cat /tmp/unity-return.log || true
 
       - name: Locate APK
         run: |
@@ -101,9 +135,3 @@ jobs:
           name: e2e-android-report-${{ inputs.plugin_version }}
           path: .af-e2e/reports/
           retention-days: 30
-
-      - name: Return Unity license
-        if: always()
-        uses: game-ci/unity-return-license@v2
-        env:
-          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -53,6 +53,28 @@ jobs:
           androidExportType: androidPackage
           allowDirtyBuild:  true
 
+      - name: Return Unity license
+        if: always()
+        run: |
+          docker run --rm \
+            --env UNITY_EMAIL \
+            --env UNITY_PASSWORD \
+            --env UNITY_SERIAL \
+            --env HOME=/root \
+            unityci/editor:ubuntu-6000.3.5f1-android-3 \
+            bash -c "
+              unity-editor -quit -batchmode -returnlicense \
+                -username \"\$UNITY_EMAIL\" \
+                -password \"\$UNITY_PASSWORD\" \
+                -logFile /tmp/unity-return.log 2>&1 || true
+              echo '=== unity-return.log ==='
+              cat /tmp/unity-return.log || true
+            " || true
+        env:
+          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+
       - name: Locate APK
         run: |
           APK=$(find test-app/Build/Android -name "*.apk" | head -1)

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -51,9 +51,6 @@ jobs:
             -o /tmp/Unity.tar.xz
           sudo mkdir -p /opt/unity
           sudo tar -xf /tmp/Unity.tar.xz -C /opt/unity
-          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/LinuxEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-6000.3.5f1.tar.xz" \
-            -o /tmp/Unity-Android.tar.xz
-          sudo tar -xf /tmp/Unity-Android.tar.xz -C /opt/unity
           UNITY=$(find /opt/unity -name "Unity" -type f -path "*/Editor/Unity" 2>/dev/null | head -1)
           echo "Unity installed at: $UNITY"
           echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -78,6 +78,23 @@ jobs:
             --android-sdk-version   "${{ github.event.inputs.android_sdk_version }}" \
             --ios-sdk-version       "${{ github.event.inputs.ios_sdk_version }}"
 
+      - name: Verify version bump
+        run: |
+          ANDROID_SDK="${{ github.event.inputs.android_sdk_version }}"
+          IOS_SDK="${{ github.event.inputs.ios_sdk_version }}"
+          PLUGIN="${{ github.event.inputs.plugin_version }}"
+
+          grep -q "af-android-sdk:$ANDROID_SDK" test-app/Assets/Plugins/Android/mainTemplate.gradle \
+            || { echo "::error::mainTemplate.gradle does not contain af-android-sdk:$ANDROID_SDK"; exit 1; }
+
+          grep -q "AppsFlyerFramework', '$IOS_SDK'" scripts/ios-pod-install.sh \
+            || { echo "::error::ios-pod-install.sh does not contain AppsFlyerFramework $IOS_SDK"; exit 1; }
+
+          grep -q "kAppsFlyerPluginVersion = \"$PLUGIN\"" Assets/AppsFlyer/AppsFlyer.cs \
+            || { echo "::error::AppsFlyer.cs does not contain plugin version $PLUGIN"; exit 1; }
+
+          echo "Version bump verified: plugin=$PLUGIN android-sdk=$ANDROID_SDK ios-sdk=$IOS_SDK"
+
       - name: Commit and push
         run: |
           git add \
@@ -86,6 +103,8 @@ jobs:
             Assets/AppsFlyer/Editor/AppsFlyerDependencies.xml \
             deploy/build_unity_package.sh \
             deploy/strict_mode_build_package.sh \
+            test-app/Assets/Plugins/Android/mainTemplate.gradle \
+            scripts/ios-pod-install.sh \
             CHANGELOG.md \
             README.md
           git commit -m "chore: bump to ${{ github.event.inputs.plugin_version }}" || echo "Nothing to commit"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -78,6 +78,22 @@ echo "[8/8] $STRICT_SH"
 sed -i.bak "s|PACKAGE_NAME=\"appsflyer-unity-plugin-strict-mode-[^\"]*\.unitypackage\"|PACKAGE_NAME=\"appsflyer-unity-plugin-strict-mode-${PLUGIN_VERSION}.unitypackage\"|" "$STRICT_SH"
 rm -f "${STRICT_SH}.bak"
 
+# ── 9. test-app/Assets/Plugins/Android/mainTemplate.gradle ───────────────────
+MAIN_GRADLE="test-app/Assets/Plugins/Android/mainTemplate.gradle"
+if [[ -f "$MAIN_GRADLE" ]]; then
+  echo "[9/10] $MAIN_GRADLE — af-android-sdk"
+  sed -i.bak "s|com.appsflyer:af-android-sdk:[^']*|com.appsflyer:af-android-sdk:$ANDROID_SDK_VERSION|" "$MAIN_GRADLE"
+  rm -f "${MAIN_GRADLE}.bak"
+fi
+
+# ── 10. scripts/ios-pod-install.sh ───────────────────────────────────────────
+IOS_POD_SH="scripts/ios-pod-install.sh"
+if [[ -f "$IOS_POD_SH" ]]; then
+  echo "[10/10] $IOS_POD_SH — AppsFlyerFramework"
+  sed -i.bak "s|pod 'AppsFlyerFramework', '[^']*'|pod 'AppsFlyerFramework', '$IOS_SDK_VERSION'|g" "$IOS_POD_SH"
+  rm -f "${IOS_POD_SH}.bak"
+fi
+
 # ── CHANGELOG.md — prepend new version header if not already present ──────────
 CHANGELOG="CHANGELOG.md"
 if [[ -f "$CHANGELOG" ]]; then


### PR DESCRIPTION
## Summary

Critical bug: the E2E pipeline was building and running against the **old** native SDK versions, not the ones passed to the pipeline.

**Root cause:**
- `bump-version.sh` only updated `AppsFlyerDependencies.xml` (used for plugin distribution)
- The E2E test builds use two different files with hardcoded versions:
  - `test-app/Assets/Plugins/Android/mainTemplate.gradle` — `af-android-sdk:6.17.6`
  - `scripts/ios-pod-install.sh` — `pod 'AppsFlyerFramework', '6.17.9'` ×2

**Evidence:** RC pipeline run with `android_sdk_version=6.18.0` / `ios_sdk_version=6.18.0` produced logs showing `AppsFlyer_6.17.6` and `version: 6.17.9`.

**Fix:** Added steps 9 and 10 to `bump-version.sh` to patch both files.

## Test plan

- [ ] Merge to `development`
- [ ] Trigger `rc-release.yml` — logs should show the requested SDK versions
- [ ] Verify `AppsFlyer_6.18.0` in Android logs and `version: 6.18.0` in iOS logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)