### PR TITLE
ci: align workflow files with master — iOS retry, regex fix

### DIFF
--- a/.github/workflows/rc-e2e-ios.yml
+++ b/.github/workflows/rc-e2e-ios.yml
@@ -61,11 +61,30 @@ jobs:
       - name: Activate Unity license
         run: |
           UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"
-          "$UNITY" -quit -batchmode \
-            -serial "${{ secrets.UNITY_SERIAL }}" \
-            -username "${{ secrets.UNITY_EMAIL }}" \
-            -password "${{ secrets.UNITY_PASSWORD }}" \
-            -logFile /tmp/unity-activate.log 2>&1 || true
+
+          activate() {
+            rm -f /tmp/unity-activate.log
+            "$UNITY" -quit -batchmode \
+              -serial   "${{ secrets.UNITY_SERIAL }}" \
+              -username "${{ secrets.UNITY_EMAIL }}" \
+              -password "${{ secrets.UNITY_PASSWORD }}" \
+              -logFile  /tmp/unity-activate.log 2>&1 || true
+          }
+
+          activate
+
+          if grep -q "serial has reached the maximum number of activations" /tmp/unity-activate.log 2>/dev/null; then
+            echo "::warning::Serial at max activations — returning existing license and retrying in 60s..."
+            "$UNITY" -quit -batchmode -returnlicense \
+              -username "${{ secrets.UNITY_EMAIL }}" \
+              -password "${{ secrets.UNITY_PASSWORD }}" \
+              -logFile  /tmp/unity-return-preflight.log 2>&1 || true
+            echo "=== preflight return log ==="
+            cat /tmp/unity-return-preflight.log || true
+            sleep 60
+            activate
+          fi
+
           grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
 
       - name: Build iOS Simulator Xcode project
@@ -102,7 +121,11 @@ jobs:
         run: |
           UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"
           "$UNITY" -quit -batchmode -returnlicense \
+            -username "${{ secrets.UNITY_EMAIL }}" \
+            -password "${{ secrets.UNITY_PASSWORD }}" \
             -logFile /tmp/unity-return.log 2>&1 || true
+          echo "=== unity-return.log ==="
+          cat /tmp/unity-return.log || true
 
       - name: Install iOS pods
         run: |

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Validate plugin_version format
         run: |
-          if ! echo "${{ github.event.inputs.plugin_version }}" | grep -qE '^\d+\.\d+\.\d+-rc\d+$'; then
+          if ! echo "${{ github.event.inputs.plugin_version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'; then
             echo "::error::plugin_version must match X.Y.Z-rcN (e.g. 6.18.0-rc1)"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Aligns `development` workflow files with the fixes already on `master`, so that a clean `development → master` PR can follow with no conflicts.

- `rc-e2e-ios.yml`: bring in retry logic for max activations + credentials on `-returnlicense` (from PRs #396/#397 on master)
- `rc-release.yml`: fix `\d` → `[0-9]+` for Linux grep compatibility (from PR #395 on master)

After this merges to `development`, a `development → master` PR will carry the remaining changes from `development` (verify step, bump-version.sh fix) with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)