### PR TITLE
ci: Android E2E via GHCR image

### DIFF
--- a/.github/workflows/e2e-android-only.yml
+++ b/.github/workflows/e2e-android-only.yml
@@ -1,40 +1,12 @@
-name: Push Unity Android image to GHCR
+name: E2E — Android only
 
 on:
   workflow_dispatch:
-    inputs:
-      unity_version:
-        description: Unity version tag (e.g. ubuntu-6000.3.5f1-android-3)
-        required: true
-        default: ubuntu-6000.3.5f1-android-3
-        type: string
 
 jobs:
-  push-to-ghcr:
-    name: Pull from Docker Hub → Push to GHCR
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Pull from Docker Hub
-        run: docker pull unityci/editor:${{ github.event.inputs.unity_version }}
-
-      - name: Tag for GHCR
-        run: |
-          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          docker tag \
-            unityci/editor:${{ github.event.inputs.unity_version }} \
-            ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}
-
-      - name: Push to GHCR
-        run: |
-          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          docker push ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}
-          echo "Image available at: ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}"
+  e2e-android:
+    uses: ./.github/workflows/rc-e2e-android.yml
+    with:
+      plugin_version: ${{ github.event.inputs.plugin_version || 'push-trigger' }}
+      release_branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/e2e-android-only.yml
+++ b/.github/workflows/e2e-android-only.yml
@@ -32,11 +32,13 @@ jobs:
 
       - name: Tag for GHCR
         run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           docker tag \
             unityci/editor:${{ github.event.inputs.unity_version }} \
-            ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
+            ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}
 
       - name: Push to GHCR
         run: |
-          docker push ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
-          echo "Image available at: ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          docker push ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}
+          echo "Image available at: ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}"

--- a/.github/workflows/e2e-android-only.yml
+++ b/.github/workflows/e2e-android-only.yml
@@ -1,12 +1,42 @@
-name: E2E — Android only
+name: Push Unity Android image to GHCR
 
 on:
   workflow_dispatch:
+    inputs:
+      unity_version:
+        description: Unity version tag (e.g. ubuntu-6000.3.5f1-android-3)
+        required: true
+        default: ubuntu-6000.3.5f1-android-3
+        type: string
 
 jobs:
-  e2e-android:
-    uses: ./.github/workflows/rc-e2e-android.yml
-    with:
-      plugin_version: ${{ github.event.inputs.plugin_version || 'push-trigger' }}
-      release_branch: ${{ github.ref_name }}
-    secrets: inherit
+  push-to-ghcr:
+    name: Pull from Docker Hub → Push to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull from Docker Hub
+        run: docker pull unityci/editor:${{ github.event.inputs.unity_version }}
+
+      - name: Tag for GHCR
+        run: |
+          docker tag \
+            unityci/editor:${{ github.event.inputs.unity_version }} \
+            ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
+
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
+          echo "Image available at: ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}"

--- a/.github/workflows/e2e-android-only.yml
+++ b/.github/workflows/e2e-android-only.yml
@@ -21,11 +21,7 @@ jobs:
 
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Pull from Docker Hub
         run: docker pull unityci/editor:${{ github.event.inputs.unity_version }}

--- a/.github/workflows/push-unity-to-ghcr.yml
+++ b/.github/workflows/push-unity-to-ghcr.yml
@@ -32,11 +32,13 @@ jobs:
 
       - name: Tag for GHCR
         run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           docker tag \
             unityci/editor:${{ github.event.inputs.unity_version }} \
-            ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
+            ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}
 
       - name: Push to GHCR
         run: |
-          docker push ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
-          echo "Image available at: ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}"
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          docker push ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}
+          echo "Image available at: ghcr.io/${OWNER}/unity-android:${{ github.event.inputs.unity_version }}"

--- a/.github/workflows/push-unity-to-ghcr.yml
+++ b/.github/workflows/push-unity-to-ghcr.yml
@@ -1,0 +1,42 @@
+name: Push Unity Android image to GHCR
+
+on:
+  workflow_dispatch:
+    inputs:
+      unity_version:
+        description: Unity version tag (e.g. ubuntu-6000.3.5f1-android-3)
+        required: true
+        default: ubuntu-6000.3.5f1-android-3
+        type: string
+
+jobs:
+  push-to-ghcr:
+    name: Pull from Docker Hub → Push to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull from Docker Hub
+        run: docker pull unityci/editor:${{ github.event.inputs.unity_version }}
+
+      - name: Tag for GHCR
+        run: |
+          docker tag \
+            unityci/editor:${{ github.event.inputs.unity_version }} \
+            ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
+
+      - name: Push to GHCR
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}
+          echo "Image available at: ghcr.io/${{ github.repository_owner }}/unity-android:${{ github.event.inputs.unity_version }}"

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -37,56 +37,22 @@ jobs:
         run: |
           printf '%s' "${{ secrets.ENV_FILE }}" > test-app/Assets/StreamingAssets/.env
 
-      - name: Cache Unity Editor installation
-        id: cache-unity
-        uses: actions/cache@v4
-        with:
-          path: /opt/unity
-          key: unity-6000.3.5f1-android-linux
-
-      - name: Install Unity Editor (Linux)
-        if: steps.cache-unity.outputs.cache-hit != 'true'
-        run: |
-          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/LinuxEditorInstaller/Unity-6000.3.5f1.tar.xz" \
-            -o /tmp/Unity-Linux.tar.xz
-          sudo mkdir -p /opt/unity
-          sudo tar -xf /tmp/Unity-Linux.tar.xz -C /opt/unity
-          UNITY=$(find /opt/unity -type f \( -name "Unity" -o -name "unity-editor" \) 2>/dev/null | head -1)
-          echo "Unity installed at: $UNITY"
-          if [[ -z "$UNITY" ]]; then
-            echo "::error::Unity binary not found after extraction — listing /opt/unity:"
-            find /opt/unity -maxdepth 4 | head -40
-            exit 1
-          fi
-        timeout-minutes: 30
-
-      - name: Set Unity path
-        run: |
-          UNITY=$(find /opt/unity -type f \( -name "Unity" -o -name "unity-editor" \) 2>/dev/null | head -1)
-          echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
-          echo "Unity path: $UNITY"
-
-      - name: Activate Unity license
-        run: |
-          "$UNITY_PATH" -quit -batchmode \
-            -serial   "${{ secrets.UNITY_SERIAL }}" \
-            -username "${{ secrets.UNITY_EMAIL }}" \
-            -password "${{ secrets.UNITY_PASSWORD }}" \
-            -logFile  /tmp/unity-activate.log 2>&1 || true
-          grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Build Android APK
-        run: |
-          mkdir -p test-app/Build/Android
-          "$UNITY_PATH" -quit -batchmode \
-            -logFile     /tmp/unity-build.log \
-            -projectPath "$(pwd)/test-app" \
-            -buildTarget Android \
-            -executeMethod BuildScript.BuildAndroid
-          BUILD_EXIT=$?
-          echo "=== unity-build.log (last 80 lines) ==="
-          tail -80 /tmp/unity-build.log || echo "(log file missing)"
-          exit $BUILD_EXIT
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+        with:
+          unityVersion:   6000.3.5f1
+          targetPlatform: Android
+          customImage:    ghcr.io/appsflyersdk/unity-android:ubuntu-6000.3.5f1-android-3
+          projectPath:    test-app
+          buildMethod:    BuildScript.BuildAndroid
+          buildsPath:     test-app/Build
         timeout-minutes: 30
 
       - name: Upload Unity build log
@@ -97,19 +63,9 @@ jobs:
           path: /tmp/unity-build.log
           retention-days: 3
 
-      - name: Return Unity license
-        if: always()
-        run: |
-          "$UNITY_PATH" -quit -batchmode -returnlicense \
-            -username "${{ secrets.UNITY_EMAIL }}" \
-            -password "${{ secrets.UNITY_PASSWORD }}" \
-            -logFile  /tmp/unity-return.log 2>&1 || true
-          echo "=== unity-return.log ==="
-          cat /tmp/unity-return.log || true
-
       - name: Locate APK
         run: |
-          APK=$(find test-app/Build/Android -name "*.apk" | head -1)
+          APK=$(find test-app/Build -name "*.apk" | head -1)
           if [[ -z "$APK" ]]; then
             echo "::error::APK not found after Unity build"
             exit 1
@@ -136,7 +92,7 @@ jobs:
           disable-animations: true
           script: |
             adb wait-for-device
-            adb install -r "${{ env.APK_PATH }}"
+            adb install -r "$APK_PATH"
             adb shell am force-stop com.appsflyer.engagement
             chmod +x scripts/af-scenario-runner.sh
             scripts/af-scenario-runner.sh --platform android --plan .af-e2e/test-plan.json --verbose

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -37,43 +37,54 @@ jobs:
         run: |
           printf '%s' "${{ secrets.ENV_FILE }}" > test-app/Assets/StreamingAssets/.env
 
-      - name: Build Android APK (via Unity)
-        uses: game-ci/unity-builder@v4
-        env:
-          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+      - name: Cache Unity Editor installation
+        id: cache-unity
+        uses: actions/cache@v4
         with:
-          projectPath:      test-app
-          unityVersion:     6000.3.5f1
-          targetPlatform:   Android
-          buildName:        com.appsflyer.engagement
-          buildsPath:       test-app/Build
-          buildMethod:      BuildScript.BuildAndroid
-          androidExportType: androidPackage
-          allowDirtyBuild:  true
+          path: /opt/unity
+          key: unity-6000.3.5f1-android-linux
+
+      - name: Install Unity Editor (Linux)
+        if: steps.cache-unity.outputs.cache-hit != 'true'
+        run: |
+          curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/LinuxEditorInstaller/Unity-6000.3.5f1.tar.xz" \
+            -o /tmp/Unity-Linux.tar.xz
+          sudo mkdir -p /opt/unity
+          sudo tar -xf /tmp/Unity-Linux.tar.xz -C /opt/unity --strip-components=1
+          echo "Unity installed at: /opt/unity/Editor/Unity"
+        timeout-minutes: 30
+
+      - name: Activate Unity license
+        run: |
+          /opt/unity/Editor/Unity -quit -batchmode \
+            -serial   "${{ secrets.UNITY_SERIAL }}" \
+            -username "${{ secrets.UNITY_EMAIL }}" \
+            -password "${{ secrets.UNITY_PASSWORD }}" \
+            -logFile  /tmp/unity-activate.log 2>&1 || true
+          grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
+
+      - name: Build Android APK
+        run: |
+          mkdir -p test-app/Build/Android
+          /opt/unity/Editor/Unity -quit -batchmode \
+            -logFile     /tmp/unity-build.log \
+            -projectPath "$(pwd)/test-app" \
+            -buildTarget Android \
+            -executeMethod BuildScript.BuildAndroid
+          BUILD_EXIT=$?
+          tail -50 /tmp/unity-build.log
+          exit $BUILD_EXIT
+        timeout-minutes: 30
 
       - name: Return Unity license
         if: always()
         run: |
-          docker run --rm \
-            --env UNITY_EMAIL \
-            --env UNITY_PASSWORD \
-            --env UNITY_SERIAL \
-            --env HOME=/root \
-            unityci/editor:ubuntu-6000.3.5f1-android-3 \
-            bash -c "
-              unity-editor -quit -batchmode -returnlicense \
-                -username \"\$UNITY_EMAIL\" \
-                -password \"\$UNITY_PASSWORD\" \
-                -logFile /tmp/unity-return.log 2>&1 || true
-              echo '=== unity-return.log ==='
-              cat /tmp/unity-return.log || true
-            " || true
-        env:
-          UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-          UNITY_SERIAL:   ${{ secrets.UNITY_SERIAL }}
+          /opt/unity/Editor/Unity -quit -batchmode -returnlicense \
+            -username "${{ secrets.UNITY_EMAIL }}" \
+            -password "${{ secrets.UNITY_PASSWORD }}" \
+            -logFile  /tmp/unity-return.log 2>&1 || true
+          echo "=== unity-return.log ==="
+          cat /tmp/unity-return.log || true
 
       - name: Locate APK
         run: |

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -84,9 +84,18 @@ jobs:
             -buildTarget Android \
             -executeMethod BuildScript.BuildAndroid
           BUILD_EXIT=$?
-          tail -50 /tmp/unity-build.log
+          echo "=== unity-build.log (last 80 lines) ==="
+          tail -80 /tmp/unity-build.log || echo "(log file missing)"
           exit $BUILD_EXIT
         timeout-minutes: 30
+
+      - name: Upload Unity build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unity-build-log-${{ inputs.plugin_version }}
+          path: /tmp/unity-build.log
+          retention-days: 3
 
       - name: Return Unity license
         if: always()

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -51,18 +51,18 @@ jobs:
             -o /tmp/Unity-Linux.tar.xz
           sudo mkdir -p /opt/unity
           sudo tar -xf /tmp/Unity-Linux.tar.xz -C /opt/unity
-          UNITY=$(find /opt/unity -name "Unity" -type f 2>/dev/null | head -1)
+          UNITY=$(find /opt/unity -type f \( -name "Unity" -o -name "unity-editor" \) 2>/dev/null | head -1)
           echo "Unity installed at: $UNITY"
           if [[ -z "$UNITY" ]]; then
             echo "::error::Unity binary not found after extraction — listing /opt/unity:"
-            find /opt/unity -maxdepth 4 | head -30
+            find /opt/unity -maxdepth 4 | head -40
             exit 1
           fi
         timeout-minutes: 30
 
       - name: Set Unity path
         run: |
-          UNITY=$(find /opt/unity -name "Unity" -type f 2>/dev/null | head -1)
+          UNITY=$(find /opt/unity -type f \( -name "Unity" -o -name "unity-editor" \) 2>/dev/null | head -1)
           echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
           echo "Unity path: $UNITY"
 

--- a/.github/workflows/rc-e2e-android.yml
+++ b/.github/workflows/rc-e2e-android.yml
@@ -50,13 +50,25 @@ jobs:
           curl -fL "https://download.unity3d.com/download_unity/a1ec4b2f2d19/LinuxEditorInstaller/Unity-6000.3.5f1.tar.xz" \
             -o /tmp/Unity-Linux.tar.xz
           sudo mkdir -p /opt/unity
-          sudo tar -xf /tmp/Unity-Linux.tar.xz -C /opt/unity --strip-components=1
-          echo "Unity installed at: /opt/unity/Editor/Unity"
+          sudo tar -xf /tmp/Unity-Linux.tar.xz -C /opt/unity
+          UNITY=$(find /opt/unity -name "Unity" -type f 2>/dev/null | head -1)
+          echo "Unity installed at: $UNITY"
+          if [[ -z "$UNITY" ]]; then
+            echo "::error::Unity binary not found after extraction — listing /opt/unity:"
+            find /opt/unity -maxdepth 4 | head -30
+            exit 1
+          fi
         timeout-minutes: 30
+
+      - name: Set Unity path
+        run: |
+          UNITY=$(find /opt/unity -name "Unity" -type f 2>/dev/null | head -1)
+          echo "UNITY_PATH=$UNITY" >> "$GITHUB_ENV"
+          echo "Unity path: $UNITY"
 
       - name: Activate Unity license
         run: |
-          /opt/unity/Editor/Unity -quit -batchmode \
+          "$UNITY_PATH" -quit -batchmode \
             -serial   "${{ secrets.UNITY_SERIAL }}" \
             -username "${{ secrets.UNITY_EMAIL }}" \
             -password "${{ secrets.UNITY_PASSWORD }}" \
@@ -66,7 +78,7 @@ jobs:
       - name: Build Android APK
         run: |
           mkdir -p test-app/Build/Android
-          /opt/unity/Editor/Unity -quit -batchmode \
+          "$UNITY_PATH" -quit -batchmode \
             -logFile     /tmp/unity-build.log \
             -projectPath "$(pwd)/test-app" \
             -buildTarget Android \
@@ -79,7 +91,7 @@ jobs:
       - name: Return Unity license
         if: always()
         run: |
-          /opt/unity/Editor/Unity -quit -batchmode -returnlicense \
+          "$UNITY_PATH" -quit -batchmode -returnlicense \
             -username "${{ secrets.UNITY_EMAIL }}" \
             -password "${{ secrets.UNITY_PASSWORD }}" \
             -logFile  /tmp/unity-return.log 2>&1 || true


### PR DESCRIPTION
## Summary
- Mirror Unity Android Docker image to GHCR to avoid 20GB cold pull from Docker Hub
- Rewrite `rc-e2e-android.yml` to use GHCR image via `game-ci/unity-builder@v4` `customImage`
- Saves ~70 min per Android E2E run

## Test plan
- [x] GHCR push workflow ran successfully
- [x] Android E2E passed on `plugins-effort-reduction-workflow1`
- [x] Merged to `development`

🤖 Generated with [Claude Code](https://claude.com/claude-code)