### PR TITLE
fix: select Xcode 16 in iOS E2E/smoke workflow on master

### DIFF
--- a/.github/workflows/rc-e2e-ios.yml
+++ b/.github/workflows/rc-e2e-ios.yml
@@ -121,6 +121,17 @@ jobs:
 
           grep -E "LICENSE|license|error|Error" /tmp/unity-activate.log || true
 
+      - name: Select Xcode 16
+        run: |
+          XCODE16=$(find /Applications -maxdepth 1 -name "Xcode_16*.app" | sort -V | tail -1)
+          if [[ -z "$XCODE16" ]]; then
+            echo "::warning::Xcode 16 not found under /Applications, using system default"
+          else
+            sudo xcode-select -s "$XCODE16/Contents/Developer"
+            echo "Selected: $XCODE16"
+            xcodebuild -version
+          fi
+
       - name: Build iOS Simulator Xcode project
         run: |
           UNITY="${UNITY_PATH:-/Applications/Unity/Unity.app/Contents/MacOS/Unity}"

--- a/scripts/ios-pod-install.sh
+++ b/scripts/ios-pod-install.sh
@@ -15,23 +15,36 @@ if [ ! -d "$IOS_BUILD_DIR" ]; then
   exit 1
 fi
 
+# Read versions from AppsFlyerDependencies.xml — single source of truth set by bump-version.sh
+DEPS_XML="Assets/AppsFlyer/Editor/AppsFlyerDependencies.xml"
+AF_VERSION=$(grep -Eo 'name="AppsFlyerFramework" version="[^"]*"' "$DEPS_XML" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+PC_VERSION=$(grep -Eo 'name="PurchaseConnector" version="[^"]*"' "$DEPS_XML" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+if [[ -z "$AF_VERSION" ]]; then
+  echo "[ios-pod-install] ERROR: could not parse AppsFlyerFramework version from $DEPS_XML" >&2
+  exit 1
+fi
+
+echo "[ios-pod-install] AppsFlyerFramework: $AF_VERSION"
+echo "[ios-pod-install] PurchaseConnector:  ${PC_VERSION:-"(not found, skipping)"}"
 echo "[ios-pod-install] Writing Podfile to $IOS_BUILD_DIR"
 
-cat > "$IOS_BUILD_DIR/Podfile" <<'PODFILE'
+cat > "$IOS_BUILD_DIR/Podfile" <<PODFILE
 platform :ios, '15.0'
 
 use_frameworks! :linkage => :static
 
 target 'Unity-iPhone' do
-  pod 'AppsFlyerFramework', '6.18.0'
-
+  pod 'AppsFlyerFramework', '$AF_VERSION'
+$([ -n "$PC_VERSION" ] && echo "  pod 'PurchaseConnector', '$PC_VERSION'")
   target 'Unity-iPhone Tests' do
     inherit! :search_paths
   end
 end
 
 target 'UnityFramework' do
-  pod 'AppsFlyerFramework', '6.18.0'
+  pod 'AppsFlyerFramework', '$AF_VERSION'
+$([ -n "$PC_VERSION" ] && echo "  pod 'PurchaseConnector', '$PC_VERSION'")
 end
 
 post_install do |installer|


### PR DESCRIPTION
## Summary
- Cherry-picks `586fc00` onto `master` so RC Smoke (and any `workflow_run`-triggered E2E) builds iOS with the correct toolchain.
- `workflow_run`-triggered workflows + locally-referenced reusable workflows are resolved from the **default branch (master)**, not the release branch. The fix was already on `development` and `releases/6.x.x/6.18.x/6.18.1-rc1`, but RC Smoke loads `rc-e2e-ios.yml` from `master`, so the `Select Xcode 16` step never ran and the iOS build failed with a `swift_Builtin_float` linker error.

## What changed
- `rc-e2e-ios.yml`: add `Select Xcode 16` step before the build. AppsFlyerFramework 6.18.x uses Swift 6 built-in modules not present in the default Xcode 15 toolchain on `macos-14` runners.
- `ios-pod-install.sh`: parse `AppsFlyerFramework`/`PurchaseConnector` versions from `AppsFlyerDependencies.xml` instead of hardcoding, and include `PurchaseConnector` in the Podfile.

## Why master
RC Smoke is triggered via `workflow_run` on `RC Release Pipeline` completion. GitHub loads the workflow YAML from the default branch, so the Xcode 16 step must live on `master` to take effect during smoke. The `ios-pod-install.sh` half already arrives via the release-branch checkout, but is included here to keep branches consistent.

## Test plan
- [ ] Merge to `master`.
- [ ] Trigger a fresh **RC Smoke** run from `master` (Run workflow) with `rc_version=6.18.1-rc1`, `release_branch=releases/6.x.x/6.18.x/6.18.1-rc1`. Do not re-run the old run; re-runs reuse the original workflow snapshot.
- [ ] Confirm `Select Xcode 16` step runs and `Compile simulator .app` succeeds.
- [ ] Confirm `rc-smoke/github-release` check posts `success`.

Made with [Cursor](https://cursor.com)