### PR TITLE
fix: build production packages from release branch instead of master

### DIFF
--- a/.github/workflows/release_production_workflow.yml
+++ b/.github/workflows/release_production_workflow.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ needs.Prepare-Release.outputs.output2 }}
 
       - name: Set artifact name
         id: artifact
@@ -189,16 +189,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Prepare-Release.outputs.output2 }}
+          fetch-depth: 0
       - name: Create a version tag and push it
+        env:
+          RELEASE_BRANCH_NAME: ${{ needs.Prepare-Release.outputs.output2 }}
+          PLUGIN_VERSION: ${{ needs.Prepare-Release.outputs.output1 }}
         run: |
-          echo "Pushing release tag: ${{ needs.Prepare-Release.outputs.output1 }}!"
-          git checkout master
-          echo "Checked out to master"
-          git pull origin master
-          git tag "${{ needs.Prepare-Release.outputs.output1 }}"
+          echo "Pushing release tag: $PLUGIN_VERSION!"
+          git pull origin "$RELEASE_BRANCH_NAME"
+          git tag "$PLUGIN_VERSION"
           echo "Created release tag"
-          git push origin "${{needs.Prepare-Release.outputs.output1}}"
-          echo "Pushed release tag ${{ needs.Prepare-Release.outputs.output1 }}"
+          git push origin "$PLUGIN_VERSION"
+          echo "Pushed release tag $PLUGIN_VERSION"
 
   Release-To-Production:
     needs: [Prepare-Release, Build-Production-Packages, Check-Packages, Generate-Tag]
@@ -247,12 +251,12 @@ jobs:
           else echo "failed_stage=Release-To-Production" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout master
+      - name: Checkout release branch
         if: steps.status.outputs.success == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: master
+          ref: ${{ needs.Prepare-Release.outputs.output2 }}
 
       - name: Extract changelog snippet
         id: changelog


### PR DESCRIPTION
## Summary

- `Build-Production-Packages` now checks out `RELEASE_BRANCH_NAME` instead of `master`
- `Generate-Tag` now tags the release branch HEAD instead of master
- `notify-team` Slack step reads SDK versions from the release branch

## Why

Backport releases (e.g. 6.17.900 while master is at 6.18.x) were building from master, producing a package with the wrong SDK versions. This also caused `Generate-Tag` to tag the wrong commit.

## Test plan
- [ ] Merge this PR
- [ ] Trigger `workflow_dispatch` on release 6.17.900 — verify it checks out the release branch and builds correct SDK versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)