### PR TITLE
fix: convert inline style to JSX syntax

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -30,7 +30,7 @@ To do so, please follow [this article](https://support.appsflyer.com/hc/en-us/ar
 
 ## Plugin Github Repository
 
-<a style="display: none" href="https://github.com/AppsFlyerSDK/appsflyer-unity-plugin"></a>
+<a style={{display: "none"}} href="https://github.com/AppsFlyerSDK/appsflyer-unity-plugin"></a>
 
 > 📘 Github repository for this plugin is [here](https://github.com/AppsFlyerSDK/appsflyer-unity-plugin)
 


### PR DESCRIPTION
@af-margot: Please approve and merge: Fix inline style attribute on <a> tag in Introduction.md to use JSX object syntax (style={{display: "none"}}) instead of HTML string syntax (style="display: none"). This resolves an "Unable to render content" MDXish rendering error caused by HTML string-style attributes on inline elements outside [block:html] blocks.